### PR TITLE
Updated code to permit webhook requests for more than just messages:created

### DIFF
--- a/ciscosparkbot/Spark.py
+++ b/ciscosparkbot/Spark.py
@@ -25,7 +25,8 @@ class SparkBot(Flask):
     def __init__(self, spark_bot_name, spark_bot_token=None,
                  spark_api_url=None,
                  spark_bot_email=None, spark_bot_url=None,
-                 default_action="/help", debug=False, wh_resource="messages", wh_event="created"):
+                 default_action="/help", debug=False, wh_resource="messages",
+                 wh_event="created"):
         """
         Initialize a new SparkBot
 
@@ -109,7 +110,9 @@ class SparkBot(Flask):
         # Setup the Spark Connection
         globals()["spark"] = CiscoSparkAPI(access_token=self.spark_bot_token)
         globals()["webhook"] = self.setup_webhook(self.spark_bot_name,
-                                                  self.spark_bot_url, self.wh_resource, self.wh_event)
+                                                  self.spark_bot_url,
+                                                  self.wh_resource,
+                                                  self.wh_event)
         sys.stderr.write("Configuring Webhook. \n")
         sys.stderr.write("Webhook ID: " + globals()["webhook"].id + "\n")
 
@@ -119,6 +122,8 @@ class SparkBot(Flask):
         Setup Spark WebHook to send incoming messages to this bot.
         :param name: Name of the WebHook
         :param targeturl: Target URL for WebHook
+        :param wh_resource: WebHook 'resource', such as messages, memberships, etc.
+        :param wh_event: WebHook 'event', such as created, or all
         :return: WebHook
         """
         # Get a list of current webhooks
@@ -141,7 +146,8 @@ class SparkBot(Flask):
                                             resource=wh_resource,
                                             event=wh_event)
 
-        # if we have an existing webhook, delete and recreate (can't update resource/event)
+        # if we have an existing webhook, delete and recreate
+        # (can't update resource/event)
         else:
             # Need try block because if there are NO webhooks it throws error
             try:
@@ -215,7 +221,6 @@ class SparkBot(Flask):
         """
         return "I'm Alive"
 
-
     def process_incoming_message(self):
         """
         Process an incoming message, determine the command and action,
@@ -230,9 +235,10 @@ class SparkBot(Flask):
         # Determine the Spark Room to send reply to
         room_id = post_data["data"]["roomId"]
 
-        if post_data["resource"] != "messages":
-            if post_data["resource"] in self.commands.keys():
-                reply = self.commands[post_data["resource"]]["callback"](self, post_data)
+        rsc = post_data["resource"]
+        if rsc != "messages":
+            if rsc in self.commands.keys():
+                reply = self.commands[rsc]["callback"](self, post_data)
             else:
                 return ""
         elif post_data["resource"] == "messages":

--- a/ciscosparkbot/Spark.py
+++ b/ciscosparkbot/Spark.py
@@ -122,8 +122,8 @@ class SparkBot(Flask):
         Setup Spark WebHook to send incoming messages to this bot.
         :param name: Name of the WebHook
         :param targeturl: Target URL for WebHook
-        :param wh_resource: WebHook 'resource', such as messages, memberships, etc.
-        :param wh_event: WebHook 'event', such as created, or all
+        :param wh_resource: WebHook 'resource'; messages, memberships, etc.
+        :param wh_event: WebHook 'event'; created, or all
         :return: WebHook
         """
         # Get a list of current webhooks

--- a/ciscosparkbot/Spark.py
+++ b/ciscosparkbot/Spark.py
@@ -25,7 +25,7 @@ class SparkBot(Flask):
     def __init__(self, spark_bot_name, spark_bot_token=None,
                  spark_api_url=None,
                  spark_bot_email=None, spark_bot_url=None,
-                 default_action="/help", debug=False):
+                 default_action="/help", debug=False, wh_resource="messages", wh_event="created"):
         """
         Initialize a new SparkBot
 
@@ -54,6 +54,8 @@ class SparkBot(Flask):
         self.spark_bot_email = spark_bot_email
         self.spark_bot_url = spark_bot_url
         self.default_action = default_action
+        self.wh_resource = wh_resource
+        self.wh_event = wh_event
 
         # Create Spark API Object for interacting with Spark
         if (spark_api_url):
@@ -107,12 +109,12 @@ class SparkBot(Flask):
         # Setup the Spark Connection
         globals()["spark"] = CiscoSparkAPI(access_token=self.spark_bot_token)
         globals()["webhook"] = self.setup_webhook(self.spark_bot_name,
-                                                  self.spark_bot_url)
+                                                  self.spark_bot_url, self.wh_resource, self.wh_event)
         sys.stderr.write("Configuring Webhook. \n")
         sys.stderr.write("Webhook ID: " + globals()["webhook"].id + "\n")
 
     # noinspection PyMethodMayBeStatic
-    def setup_webhook(self, name, targeturl):
+    def setup_webhook(self, name, targeturl, wh_resource, wh_event):
         """
         Setup Spark WebHook to send incoming messages to this bot.
         :param name: Name of the WebHook
@@ -136,16 +138,18 @@ class SparkBot(Flask):
             sys.stderr.write("Creating new webhook.\n")
             wh = self.spark.webhooks.create(name=name,
                                             targetUrl=targeturl,
-                                            resource="messages",
-                                            event="created")
+                                            resource=wh_resource,
+                                            event=wh_event)
 
-        # if we have an existing webhook update it
+        # if we have an existing webhook, delete and recreate (can't update resource/event)
         else:
             # Need try block because if there are NO webhooks it throws error
             try:
-                wh = self.spark.webhooks.update(webhookId=wh.id,
-                                                name=name,
-                                                targetUrl=targeturl)
+                wh = self.spark.webhooks.delete(webhookId=wh.id)
+                wh = self.spark.webhooks.create(name=name,
+                                                targetUrl=targeturl,
+                                                resource=wh_resource,
+                                                event=wh_event)
             # https://github.com/CiscoDevNet/ciscosparkapi/blob/master/ciscosparkapi/api/webhooks.py#L237
             except Exception as e:
                 msg = "Encountered an error updating webhook: {}"
@@ -211,12 +215,14 @@ class SparkBot(Flask):
         """
         return "I'm Alive"
 
+    # noinspection PyPackageRequirements
     def process_incoming_message(self):
         """
         Process an incoming message, determine the command and action,
         and determine reply.
         :return:
         """
+        reply = None
 
         # Get the webhook data
         post_data = request.json
@@ -224,48 +230,54 @@ class SparkBot(Flask):
         # Determine the Spark Room to send reply to
         room_id = post_data["data"]["roomId"]
 
-        # Get the details about the message that was sent.
-        message_id = post_data["data"]["id"]
-        message = self.spark.messages.get(message_id)
-        if self.DEBUG:
-            sys.stderr.write("Message content:" + "\n")
-            sys.stderr.write(str(message) + "\n")
-
-        # First make sure not processing a message from the bots
-        # Needed to avoid the bot talking to itself
-        # We check using IDs instead of emails since the email
-        # of the bot could change while the bot is running
-        # for example from bot@sparkbot.io to bot@webex.bot
-        if message.personId in self.spark.people.me().id:
+        if post_data["resource"] != "messages":
+            if post_data["resource"] in self.commands.keys():
+                reply = self.commands[post_data["resource"]]["callback"](self, post_data)
+            else:
+                return ""
+        elif post_data["resource"] == "messages":
+            # Get the details about the message that was sent.
+            message_id = post_data["data"]["id"]
+            message = self.spark.messages.get(message_id)
             if self.DEBUG:
-                sys.stderr.write("Ignoring message from our self" + "\n")
-            return ""
+                sys.stderr.write("Message content:" + "\n")
+                sys.stderr.write(str(message) + "\n")
 
-        # Log details on message
-        sys.stderr.write("Message from: " + message.personEmail + "\n")
+            # First make sure not processing a message from the bots
+            # Needed to avoid the bot talking to itself
+            # We check using IDs instead of emails since the email
+            # of the bot could change while the bot is running
+            # for example from bot@sparkbot.io to bot@webex.bot
+            if message.personId in self.spark.people.me().id:
+                if self.DEBUG:
+                    sys.stderr.write("Ignoring message from our self" + "\n")
+                return ""
 
-        # Find the command that was sent, if any
-        command = ""
-        for c in self.commands.items():
-            if message.text.find(c[0]) != -1:
-                command = c[0]
-                sys.stderr.write("Found command: " + command + "\n")
-                # If a command was found, stop looking for others
-                break
+            # Log details on message
+            sys.stderr.write("Message from: " + message.personEmail + "\n")
 
-        # Build the reply to the user
-        reply = ""
+            # Find the command that was sent, if any
+            command = ""
+            for c in self.commands.items():
+                if message.text.find(c[0]) != -1:
+                    command = c[0]
+                    sys.stderr.write("Found command: " + command + "\n")
+                    # If a command was found, stop looking for others
+                    break
 
-        # Take action based on command
-        # If no command found, send the default_action
-        if command in [""] and self.default_action:
-            # noinspection PyCallingNonCallable
-            reply = self.commands[self.default_action]["callback"](message)
-        elif command in self.commands.keys():
-            # noinspection PyCallingNonCallable
-            reply = self.commands[command]["callback"](message)
-        else:
-            pass
+            # Build the reply to the user
+            reply = ""
+
+            # Take action based on command
+            # If no command found, send the default_action
+            if command in [""] and self.default_action:
+                # noinspection PyCallingNonCallable
+                reply = self.commands[self.default_action]["callback"](message)
+            elif command in self.commands.keys():
+                # noinspection PyCallingNonCallable
+                reply = self.commands[command]["callback"](message)
+            else:
+                pass
 
         # allow command handlers to craft their own Spark message
         if reply and isinstance(reply, Response):

--- a/ciscosparkbot/Spark.py
+++ b/ciscosparkbot/Spark.py
@@ -215,7 +215,7 @@ class SparkBot(Flask):
         """
         return "I'm Alive"
 
-    # noinspection PyPackageRequirements
+
     def process_incoming_message(self):
         """
         Process an incoming message, determine the command and action,

--- a/tests/spark_mock.py
+++ b/tests/spark_mock.py
@@ -81,14 +81,14 @@ class MockSparkAPI:
             'ownedBy': 'creator',
             'status': 'active',
             'created': '2018-09-13T19:35:51.248Z',
-            'actorId': 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9mOTc4ZDQ2NS1kZWI0LTQxZTgtYWNkMi1iNjI5ZDc1ODU5N2E',
+            'actorId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
             'data': {
                 'id': 'incoming_membership_id',
                 'roomId': 'some_room_id',
                 'personId': 'some_person_id',
                 'personEmail': 'matt@example.com',
                 'personDisplayName': 'Matt',
-                'personOrgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+                'personOrgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNk',
                 'isModerator': False,
                 'isMonitor': False,
                 'created': '2018-09-13T19:35:58.803Z'
@@ -110,21 +110,21 @@ class MockSparkAPI:
             'ownedBy': 'creator',
             'status': 'active',
             'created': '2018-09-13T19:35:51.248Z',
-            'actorId': 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9mOTc4ZDQ2NS1kZWI0LTQxZTgtYWNkMi1iNjI5ZDc1ODU5N2E',
+            'actorId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
             'data': {
                 'id': 'incoming_membership_id',
                 'roomId': 'some_room_id',
                 'personId': 'some_person_id',
                 'personEmail': 'matt@cisco.com',
                 'personDisplayName': 'Matt',
-                'personOrgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+                'personOrgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNk',
                 'isModerator': False,
                 'isMonitor': False,
                 'created': '2018-09-13T19:35:58.803Z'
             }
         }
         return json.dumps(data)
-    
+
     @classmethod
     def get_message_help(cls):
         data = {

--- a/tests/spark_mock.py
+++ b/tests/spark_mock.py
@@ -68,6 +68,64 @@ class MockSparkAPI:
         return json.dumps(data)
 
     @classmethod
+    def incoming_membership_fail(cls):
+        data = {
+            'id': 'newwebhook',
+            'name': 'My Awesome Webhook',
+            'targetUrl': 'https://example.com/mywebhook',
+            'resource': 'memberships',
+            'event': 'created',
+            'orgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+            'createdBy': 'fdsafdsf',
+            'appId': 'asdfasdfsadf',
+            'ownedBy': 'creator',
+            'status': 'active',
+            'created': '2018-09-13T19:35:51.248Z',
+            'actorId': 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9mOTc4ZDQ2NS1kZWI0LTQxZTgtYWNkMi1iNjI5ZDc1ODU5N2E',
+            'data': {
+                'id': 'incoming_membership_id',
+                'roomId': 'some_room_id',
+                'personId': 'some_person_id',
+                'personEmail': 'matt@example.com',
+                'personDisplayName': 'Matt',
+                'personOrgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+                'isModerator': False,
+                'isMonitor': False,
+                'created': '2018-09-13T19:35:58.803Z'
+            }
+        }
+        return json.dumps(data)
+
+    @classmethod
+    def incoming_membership_pass(cls):
+        data = {
+            'id': 'newwebhook',
+            'name': 'My Awesome Webhook',
+            'targetUrl': 'https://example.com/mywebhook',
+            'resource': 'memberships',
+            'event': 'created',
+            'orgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+            'createdBy': 'fdsafdsf',
+            'appId': 'asdfasdfsadf',
+            'ownedBy': 'creator',
+            'status': 'active',
+            'created': '2018-09-13T19:35:51.248Z',
+            'actorId': 'Y2lzY29zcGFyazovL3VzL1BFT1BMRS9mOTc4ZDQ2NS1kZWI0LTQxZTgtYWNkMi1iNjI5ZDc1ODU5N2E',
+            'data': {
+                'id': 'incoming_membership_id',
+                'roomId': 'some_room_id',
+                'personId': 'some_person_id',
+                'personEmail': 'matt@cisco.com',
+                'personDisplayName': 'Matt',
+                'personOrgId': 'OTZhYmMyYWEtM2RjYy0xMWU1LWExNTItZmUzNDgxOWNkYzlh',
+                'isModerator': False,
+                'isMonitor': False,
+                'created': '2018-09-13T19:35:58.803Z'
+            }
+        }
+        return json.dumps(data)
+    
+    @classmethod
     def get_message_help(cls):
         data = {
           "id": "some_message_id",

--- a/tests/sparkbot.py
+++ b/tests/sparkbot.py
@@ -2,7 +2,6 @@ import unittest
 from ciscosparkbot import SparkBot
 import requests_mock
 from .spark_mock import MockSparkAPI
-import json
 
 
 class SparkBotTests(unittest.TestCase):

--- a/tests/sparkbot.py
+++ b/tests/sparkbot.py
@@ -2,6 +2,7 @@ import unittest
 from ciscosparkbot import SparkBot
 import requests_mock
 from .spark_mock import MockSparkAPI
+import json
 
 
 class SparkBotTests(unittest.TestCase):
@@ -118,6 +119,91 @@ class SparkBotTests(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         print(resp.data)
         self.assertIn(b'I understand the following commands', resp.data)
+
+    @requests_mock.mock()
+    def test_process_incoming_membership_check_sender_fail(self, m):
+        m.get('https://api.ciscospark.com/v1/webhooks',
+              json=MockSparkAPI.list_webhooks())
+        m.post('https://api.ciscospark.com/v1/webhooks',
+               json=MockSparkAPI.create_webhook())
+        m.post('//api.ciscospark.com/v1/messages', json={})
+        bot_email = "test@test.com"
+        spark_token = "somefaketoken"
+        bot_url = "http://fakebot.com"
+        bot_app_name = "testbot"
+        # Create a new bot
+        bot = SparkBot(bot_app_name,
+                       spark_bot_token=spark_token,
+                       spark_bot_url=bot_url,
+                       spark_bot_email=bot_email,
+                       debug=True,
+                       wh_resource="memberships",
+                       wh_event="all")
+
+        # Add new command
+        bot.add_command('memberships',
+                        '*',
+                        self.check_membership)
+        bot.testing = True
+        self.app = bot.test_client()
+
+        resp = self.app.post('/',
+                             data=MockSparkAPI.incoming_membership_fail(),
+                             content_type="application/json")
+        self.assertEqual(resp.status_code, 200)
+        print(resp.data)
+        self.assertIn(b"failed", resp.data)
+
+    @requests_mock.mock()
+    def test_process_incoming_membership_check_sender_pass(self, m):
+        m.get('https://api.ciscospark.com/v1/webhooks',
+              json=MockSparkAPI.list_webhooks())
+        m.post('https://api.ciscospark.com/v1/webhooks',
+               json=MockSparkAPI.create_webhook())
+        m.post('//api.ciscospark.com/v1/messages', json={})
+        bot_email = "test@test.com"
+        spark_token = "somefaketoken"
+        bot_url = "http://fakebot.com"
+        bot_app_name = "testbot"
+        # Create a new bot
+        bot = SparkBot(bot_app_name,
+                       spark_bot_token=spark_token,
+                       spark_bot_url=bot_url,
+                       spark_bot_email=bot_email,
+                       debug=True,
+                       wh_resource="memberships",
+                       wh_event="all")
+
+        # Add new command
+        bot.add_command('memberships',
+                        '*',
+                        self.check_membership)
+        bot.testing = True
+        self.app = bot.test_client()
+
+        resp = self.app.post('/',
+                             data=MockSparkAPI.incoming_membership_pass(),
+                             content_type="application/json")
+        self.assertEqual(resp.status_code, 200)
+        print(resp.data)
+        self.assertIn(b"success", resp.data)
+
+    def check_membership(self, ob, incoming_msg):
+        """
+        Sample function to do some action.
+        :param incoming_msg: The incoming message object from Spark
+        :param ob: Spark API object
+        :return: A text or markdown based reply
+        """
+
+        whitelist = ["cisco.com"]
+        pemail = incoming_msg["data"]["personEmail"]
+        pdom = pemail.split("@")[1]
+
+        if pdom in whitelist:
+            return "success"
+        else:
+            return "failed"
 
     @requests_mock.mock()
     def test_process_incoming_message_default_command(self, m):


### PR DESCRIPTION
I was in need of a bot that could monitor memberships data, so I extended this one to do that.

With the changes in the PR, the default behavior is still in tact. However, here is an example of how you would monitor memberships data:

In your main code, when you create an instance of the bot, add the "wh_resource" and "wh_event" parameters:
```
bot = SparkBot(bot_app_name, spark_bot_token=spark_token,
               spark_bot_url=bot_url, spark_bot_email=bot_email, debug=True,
               wh_resource="memberships", wh_event="all")
```

Then, add a new command for the resource you want to monitor:
`bot.add_command('memberships', '*', check_memberships)
`

Finally, add a function to handle that command. For example, I needed the bot (which is assigned to the room as a moderator) to be able to remove anyone from a room who is not in a set of whitelisted domains (i.e., to ensure that a room stays "internal-only"). This function has an additional parameter (sp in my example), which is used to directly access the SparkAPI object.
```
def check_memberships(sp, incoming_msg):
    wl_dom = os.getenv("WHITELIST_DOMAINS")
    if wl_dom.find("[") <= 0:
        wl_dom = '["' + wl_dom + '"]'
        wl_dom = wl_dom.replace(",", '","')

    if wl_dom and incoming_msg["event"] != "deleted":
        pemail = incoming_msg["data"]["personEmail"]
        pdom = pemail.split("@")[1]
        plist = json.loads(wl_dom)
        print(pemail, pdom, plist)
        if pdom in plist or pemail == bot_email:
            # membership check succeeded
            return ""
        else:
            # membership check failed
            print("membership failed. deleting " + incoming_msg["data"]["id"])
            sp.spark.memberships.delete(incoming_msg["data"]["id"])
            return "'" + pemail + "' was automatically removed from this space; it is restricted to only " \
                                  "internal users."
    else:
        return ""
```